### PR TITLE
Fix a typo in the StorageClass yaml

### DIFF
--- a/incubator/nfs-provisioner/templates/class.yaml
+++ b/incubator/nfs-provisioner/templates/class.yaml
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: {{ .Values.storageClass }}
   {{ if .Values.defaultClass }}
-  label:
+  labels:
     storageclass.beta.kubernetes.io/is-default-class: true
   {{ end }}
 provisioner: {{ .Values.provisionerName }}


### PR DESCRIPTION
Without this fix, helm chokes on the `metadata.label` definition, because it's not a valid field according to the api.